### PR TITLE
bugfix: 헤더 팝업메뉴 헤더버튼에 고정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import './App.css';
 import HeaderBar from './components/HeaderBar';
+import GrantTable from './components/GrantTable';
+import Footer from './components/Footer/Footer';
+
 function App() {
   return (
     <div className="App">
       <HeaderBar></HeaderBar>
+      <GrantTable />
+      <Footer />
     </div>
   );
 }

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -28,8 +28,10 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function HeaderBar() {
   const classes = useStyles();
   const [isOpened, setIsOpened] = useState(false);
-  const handleClick = () => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setIsOpened(!isOpened);
+    setAnchorEl(event.currentTarget);
   };
 
   return (
@@ -43,7 +45,7 @@ export default function HeaderBar() {
             aria-label="menu"
             onClick={handleClick}
           >
-            <HeaderBarMenu isOpened={isOpened}></HeaderBarMenu>
+            <HeaderBarMenu isOpened={isOpened} anchorEl={anchorEl}></HeaderBarMenu>
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" className={classes.title}>

--- a/src/components/HeaderBarMenu.tsx
+++ b/src/components/HeaderBarMenu.tsx
@@ -38,6 +38,7 @@ const StyledMenuItem = withStyles((theme) => ({
 
 interface Props {
   isOpened: boolean;
+  anchorEl: HTMLElement | null;
 }
 
 type Menu = {
@@ -46,10 +47,10 @@ type Menu = {
 
 const menuList: Array<Menu> = [{ primary: 'menu1' }, { primary: 'menu2' }, { primary: 'menu3' }];
 
-export default function HeaderBarMenu({ isOpened }: Props) {
+export default function HeaderBarMenu({ isOpened, anchorEl }: Props) {
   return (
     <div>
-      <StyledMenu id="customized-menu" keepMounted open={isOpened}>
+      <StyledMenu id="customized-menu" anchorEl={anchorEl} keepMounted open={isOpened}>
         {menuList.map((menu) => (
           <StyledMenuItem key={menu.primary}>
             <ListItemText primary={menu.primary} />


### PR DESCRIPTION
헤더 팝업메뉴 버튼 클릭시 확장된 메뉴 엉뚱한 곳에 위치
-> 팝업메뉴 버튼 바로 밑으로 수정